### PR TITLE
No more stringly typed.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -334,22 +334,22 @@ fn solve_line(line: Vec<&str>, nums: Vec<usize>) -> anyhow::Result<Vec<&str>> {
     for i in 0..len {
         let cb_filled = possiblities[i].could_be_filled;
         let cb_empty = possiblities[i].could_be_empty;
-        if cb_filled == "T" && cb_empty == "T" {
+        if cb_filled == IsFilled::Yes && cb_empty == IsFilled::Yes {
             //we don't know whic yet
             new_line.push("2");
-        } else if cb_filled == "T" {
+        } else if cb_filled == IsFilled::Yes {
             //confirm fill whether Empty is deconfirmed or uninitialized
             new_line.push("1");
-        } else if cb_empty == "T" {
+        } else if cb_empty == IsFilled::Yes {
             //confirm empty whether Filled is deconfirmed or uninitialized
             new_line.push("0");
-        } else if cb_filled == "F" && cb_empty == "F" {
+        } else if cb_filled == IsFilled::No && cb_empty == IsFilled::No {
             //if both are deconfirmed then there is a contradiction in the logic
             anyhow::bail!("Contradiction found");
-        } else if cb_filled == "F" {
+        } else if cb_filled == IsFilled::No {
             //deconfirmed Filled, while Empty uninitialized, can say empty
             new_line.push("0");
-        } else if cb_empty == "F" {
+        } else if cb_empty == IsFilled::No {
             //deconfirmed Empty, while Filled uninitialized, can say empty
             new_line.push("1");
         }
@@ -455,9 +455,16 @@ fn theres_room(line: Vec<&str>, index: i8, num: i8, dir: i8) -> bool {
     true
 }
 
-struct Square<'a> {
-    could_be_filled: &'a str,
-    could_be_empty: &'a str,
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum IsFilled {
+    Unknown,
+    Yes,
+    No,
+}
+
+struct Square {
+    could_be_filled: IsFilled,
+    could_be_empty: IsFilled,
 }
 
 trait Possibility {
@@ -470,49 +477,49 @@ trait Possibility {
     fn cant_be_empty(&mut self);
 }
 
-impl Possibility for Square<'_> {
-    fn new() -> Square<'static> {
-        return Square {
-            could_be_filled: "",
-            could_be_empty: "",
-        };
+impl Possibility for Square {
+    fn new() -> Self {
+        Self {
+            could_be_filled: IsFilled::Unknown,
+            could_be_empty: IsFilled::Unknown,
+        }
     }
 
     fn already_filled(&mut self) {
-        self.could_be_filled = "T";
-        self.could_be_empty = "F";
+        self.could_be_filled = IsFilled::Yes;
+        self.could_be_empty = IsFilled::No;
     }
 
     fn already_empty(&mut self) {
-        self.could_be_filled = "F";
-        self.could_be_empty = "T";
+        self.could_be_filled = IsFilled::No;
+        self.could_be_empty = IsFilled::Yes;
     }
 
     fn may_be_filled(&mut self) -> anyhow::Result<()> {
-        if self.could_be_filled == "F" {
+        if self.could_be_filled == IsFilled::No {
             anyhow::bail!("Contradiction found");
         } else {
-            self.could_be_filled = "T";
+            self.could_be_filled = IsFilled::Yes;
         }
 
         Ok(())
     }
 
     fn may_be_empty(&mut self) -> anyhow::Result<()> {
-        if self.could_be_empty == "F" {
+        if self.could_be_empty == IsFilled::No {
             anyhow::bail!("Contradiction found");
         } else {
-            self.could_be_empty = "T";
+            self.could_be_empty = IsFilled::Yes;
         }
 
         Ok(())
     }
 
     fn cant_be_filled(&mut self) {
-        self.could_be_filled = "F";
+        self.could_be_filled = IsFilled::No;
     }
 
     fn cant_be_empty(&mut self) {
-        self.could_be_empty = "F";
+        self.could_be_empty = IsFilled::No;
     }
 }


### PR DESCRIPTION
The `Square` struct used whats known as "stringly" typed data. That is, we used:

- "T" to signify `true`
- "F" to signify `false`
- "" to signify unknown

We can provide a finite multi-state value such as this more succinctly using enums (other languages have this feature too).

For example we could say that these three states are represented by `IsFilled`:
```rust
enum IsFilled {
    Unknown,
    Yes,
    No,
}
```
See also https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html

Now that we have the enum `IsFilled` we can represent the stringly typed "T", "F", and "" efficiently and succinctly. 

Another way to do this would be to use https://doc.rust-lang.org/std/option/. We could have made the type `Option<bool>`. `Option` is an extremely common `enum` provided by Rust. It looks like:
```rust
enum Option<T> {
    Some(T),
    None,
}
```

Where `T` is some type. In the case of `Option<bool>`: `T` is of type `bool`.

This lets us say: There could be a bool, or no bool.

`Option` can sort of be thought of as `null` values from other languages. 

What does `derive` do?
```rust
#[derive(PartialEq, Eq, Clone, Copy)]
```

Which is a macro that tells the Rust compiler to add some `trait impl`s to `IsFilled` for us. This makes `PartialEq` and `Eq` let us do comparison with `IsFilled` (think `IsFilled::Yes == IsFilled::Yes` etc.). `Copy` and `Copy` are explained further here: https://doc.rust-lang.org/std/clone/trait.Clone.html

A derive macro lets us say "we would like this thing to implement this kind of trait." And the compiler will try to do that for us. See also https://doc.rust-lang.org/rust-by-example/trait/derive.html.